### PR TITLE
font size fix for webkit browsers

### DIFF
--- a/streetsign_server/post_types/external_webpage/screen.js
+++ b/streetsign_server/post_types/external_webpage/screen.js
@@ -10,11 +10,11 @@
                   + '">...</iframe>');
 
         if (('type' in data.zone ) && ( data.zone.type == 'scroll')) {
-            newhtml = $('<div class="post post_html post_scrolling"><div class="post_inner">'
+            newhtml = $('<div class="post post_html post_scrolling"><div class="post_inner post_reset_fontsize">'
                         + newhtml
                         + '</div></div>').prependTo(zone);
         } else {
-            newhtml = $('<div class="post post_html"><div class="post_inner">'
+            newhtml = $('<div class="post post_html"><div class="post_inner post_reset_fontsize">'
                     + newhtml
                     + '</div></div>')
                     .prependTo(zone);

--- a/streetsign_server/static/screens/main.css
+++ b/streetsign_server/static/screens/main.css
@@ -63,6 +63,10 @@ div.zone {
     bottom: 0px;
 }
 
+.zone_ .post_html .post_inner.post_reset_fontsize, .zone_fade .post_html .post_inner.post_reset_fontsize {
+    font-size: 0px;
+}
+
 .text_dropshadow {
     text-shadow: 1px 1px 3px rgba(0, 0, 0, 1);
 }


### PR DESCRIPTION
For some unknown reason, external webpages shown in an iframe are moved up because of the dynamically calculated font size.
This seems to only affect iframes and only Webkit based browsers (safari, epiphany,...).
The fix for this to add an extra class to the container for the iframe which resets the font size to zero.
Testing showed that it does not affect other engines or post types.

Screenshot before
![image](https://user-images.githubusercontent.com/6500514/82116423-fa01be80-9769-11ea-9c25-ea0323f1604f.png)
This https://streetsign.readthedocs.io/ running in Epiphany 3.28.6

Screenshot after
![image](https://user-images.githubusercontent.com/6500514/82116461-5369ed80-976a-11ea-81fe-9d68477f0082.png)