### PR TITLE
Bugfixes: simpleeval, date string, systemd

### DIFF
--- a/deployment/systemd/streetsign.service
+++ b/deployment/systemd/streetsign.service
@@ -1,8 +1,8 @@
 [Unit]
-description=Streetsign Digital Signage Server
+Description=Streetsign Digital Signage Server
 
 [Service]
-Type=Simple
+Type=simple
 WorkingDirectory=/srv/streetsign
 ExecStart=/srv/streetsign/run.py waitress
 User=streetsign

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ bleach==3.1.4
 py-bcrypt==0.4
 passlib==1.7.1
 # for parsing date-related formulae:
-simpleeval==0.9.8
+simpleeval==0.9.10
 # simple python-based WSGI webserver:
 waitress==1.4.3
 # for tests:

--- a/streetsign_server/static/screens/functions.js
+++ b/streetsign_server/static/screens/functions.js
@@ -129,7 +129,7 @@ function magic_time() {
         this.innerHTML = d.format(format);
     });
     $('.magic_date').each(function(i){
-        var format = $(this).data('format') || '%F';
+        var format = $(this).data('format') || '%d/%m/%Y';
         this.innerHTML = d.format(format); // Date().replace(/:[^:]*$/,'');
     });
     setTimeout(magic_time, 60000);


### PR DESCRIPTION
- Bump [simpleeval](https://github.com/danthedeckie/simpleeval) from 0.9.8 to 0.9.10
- Fixed magic date string
- Fixed systemd service naming convention